### PR TITLE
feat: support searching organization specific tasks

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,13 @@
       "Bash(npm*)",
       "Bash(npx*)",
       "mcp__github__*",
-      "WebFetch(domain:raw.githubusercontent.com)"
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Bash(powershell -Command \"Start-Process ''d:\\\\Repos\\\\personals\\\\azure-pipelines-mcp\\\\code-signing-prezentace.html''\")"
     ]
-  }
+  },
+  "enabledMcpjsonServers": [
+    "github",
+    "azure-pipelines"
+  ],
+  "enableAllProjectMcpServers": true
 }

--- a/src/services/azure-devops-client.ts
+++ b/src/services/azure-devops-client.ts
@@ -186,4 +186,45 @@ export class AzureDevOpsClient extends HttpClient {
 			clearTimeout(timeoutId);
 		}
 	}
+
+	/**
+	 * Získá seznam definicí tasků v organizaci.
+	 */
+	async getTaskDefinitions(): Promise<TaskDefinition[]> {
+		// Endpoint pro získání všech tasků v organizaci
+		// Dokumentace: https://learn.microsoft.com/en-us/rest/api/azure/devops/distributedtask/tasks/list
+		const result = await this.get<{ value: TaskDefinition[] }>(
+			"_apis/distributedtask/tasks"
+		);
+		return result.value;
+	}
+}
+
+export interface TaskDefinition {
+	id: string;
+	name: string;
+	friendlyName: string;
+	description: string;
+	helpMarkDown?: string;
+	category?: string;
+	visibility?: string[];
+	runsOn?: string[];
+	version: {
+		major: number;
+		minor: number;
+		patch: number;
+		isTest: boolean;
+	};
+	instanceNameFormat?: string;
+	inputs?: TaskInputDefinition[];
+}
+
+export interface TaskInputDefinition {
+	name: string;
+	type: string;
+	label: string;
+	defaultValue?: string;
+	required?: boolean;
+	helpMarkDown?: string;
+	options?: Record<string, string>;
 }

--- a/src/services/azure-devops-client.ts
+++ b/src/services/azure-devops-client.ts
@@ -206,6 +206,7 @@ export interface TaskDefinition {
 	friendlyName: string;
 	description: string;
 	helpMarkDown?: string;
+	helpUrl?: string;
 	category?: string;
 	visibility?: string[];
 	runsOn?: string[];

--- a/src/tools/search-tasks.ts
+++ b/src/tools/search-tasks.ts
@@ -164,10 +164,11 @@ function convertApiTaskToPipelineTask(apiTask: TaskDefinition): PipelineTask {
 	const version = `${apiTask.version.major}`;
 	
 	// Priorita:
-	// 1. Link extrahovaný z helpMarkDown (často přesný odkaz na learn.microsoft.com nebo GitHub)
-	// 2. Generovaný odkaz pomocí kebab-case (pro built-in tasky)
+	// 1. helpUrl (přímý odkaz)
+	// 2. Link extrahovaný z helpMarkDown (často přesný odkaz na learn.microsoft.com nebo GitHub)
+	// 3. Generovaný odkaz pomocí kebab-case (pro built-in tasky)
 	
-	let documentationPath = extractDocLink(apiTask.helpMarkDown);
+	let documentationPath = apiTask.helpUrl || extractDocLink(apiTask.helpMarkDown);
 	
 	if (!documentationPath) {
 		const kebabName = pascalToKebabCase(apiTask.name);

--- a/src/tools/task-reference.ts
+++ b/src/tools/task-reference.ts
@@ -375,7 +375,9 @@ export async function handleGetTaskReference(taskName: string): Promise<string> 
 
 	if (taskInfo) {
 		// Fetchneme dokumentaci
-		const docUrl = `${TASK_REFERENCE_BASE_URL}${taskInfo.documentationPath}`;
+		const docUrl = taskInfo.documentationPath.startsWith("http")
+			? taskInfo.documentationPath
+			: `${TASK_REFERENCE_BASE_URL}${taskInfo.documentationPath}`;
 		try {
 			const markdown = await httpClient.fetch(docUrl, { cacheTtlMs: TASK_REFERENCE_CACHE_TTL_MS });
 			const reference = parseTaskMarkdown(markdown, name, version);

--- a/src/tools/task-reference.ts
+++ b/src/tools/task-reference.ts
@@ -86,7 +86,6 @@ function generateSyntax(name: string, version: string, inputs: TaskInput[]): str
  * Extrahuje popis tasku z front matter nebo description sekce.
  */
 export function parseDescription(markdown: string): string {
-	// ... (stávající implementace)
 	// Zkusíme front matter (description: ...)
 	const frontMatterMatch = markdown.match(
 		/^---\s*\n[\s\S]*?description:\s*(.+?)\s*\n[\s\S]*?---/
@@ -105,8 +104,6 @@ export function parseDescription(markdown: string): string {
 
 	return "";
 }
-
-// ... (ostatní parsovací funkce zůstávají stejné, zkracuji pro přehlednost v replace) ...
 
 /**
  * Extrahuje první YAML syntax blok ze syntax sekce.

--- a/src/tools/task-reference.ts
+++ b/src/tools/task-reference.ts
@@ -6,6 +6,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getDefaultHttpClient, NotFoundError } from "../services/http-client.js";
 import { TASK_INDEX_URL, parseTaskIndex, type PipelineTask } from "./search-tasks.js";
+import { AzureDevOpsClient, TaskDefinition } from "../services/azure-devops-client.js";
 
 const TASK_REFERENCE_BASE_URL =
 	"https://raw.githubusercontent.com/MicrosoftDocs/azure-devops-yaml-schema/main/task-reference/";
@@ -37,9 +38,55 @@ export interface TaskReference {
 }
 
 /**
+ * Konvertuje TaskDefinition z API na formát TaskReference.
+ */
+function convertTaskDefinitionToReference(task: TaskDefinition): TaskReference {
+	const version = `${task.version.major}`;
+	const fullName = `${task.name}@${version}`;
+	
+	const inputs: TaskInput[] = task.inputs?.map(input => ({
+		name: input.name,
+		label: input.label,
+		type: input.type,
+		required: input.required ?? false,
+		defaultValue: input.defaultValue,
+		helpText: input.helpMarkDown,
+		allowedValues: input.options ? Object.keys(input.options) : undefined
+	})) ?? [];
+
+	return {
+		name: task.name,
+		version,
+		fullName,
+		description: task.description,
+		// Syntax generujeme dynamicky z vstupů pro API tasky
+		syntax: generateSyntax(task.name, version, inputs),
+		inputs,
+		outputVariables: [], // API typicky nevrací output variables strukturovaně v tomto endpointu
+		remarks: task.helpMarkDown
+	};
+}
+
+/**
+ * Generuje YAML syntaxi pro task.
+ */
+function generateSyntax(name: string, version: string, inputs: TaskInput[]): string {
+	let syntax = `- task: ${name}@${version}\n  inputs:\n`;
+	
+	for (const input of inputs) {
+		const comment = input.required ? "" : " # Optional";
+		const value = input.defaultValue ? input.defaultValue : "string";
+		syntax += `    ${input.name}: ${value}${comment}\n`;
+	}
+	
+	return syntax;
+}
+
+/**
  * Extrahuje popis tasku z front matter nebo description sekce.
  */
 export function parseDescription(markdown: string): string {
+	// ... (stávající implementace)
 	// Zkusíme front matter (description: ...)
 	const frontMatterMatch = markdown.match(
 		/^---\s*\n[\s\S]*?description:\s*(.+?)\s*\n[\s\S]*?---/
@@ -58,6 +105,8 @@ export function parseDescription(markdown: string): string {
 
 	return "";
 }
+
+// ... (ostatní parsovací funkce zůstávají stejné, zkracuji pro přehlednost v replace) ...
 
 /**
  * Extrahuje první YAML syntax blok ze syntax sekce.
@@ -282,6 +331,29 @@ async function findTaskInIndex(fullName: string): Promise<PipelineTask | null> {
 }
 
 /**
+ * Zkusí najít task pomocí Azure DevOps API.
+ */
+async function findTaskInOrganization(taskName: string, version: string): Promise<TaskReference | null> {
+	try {
+		const client = new AzureDevOpsClient();
+		const apiTasks = await client.getTaskDefinitions();
+		
+		// Najdeme přesnou shodu jména a major verze
+		const matchedTask = apiTasks.find(t => 
+			t.name.toLowerCase() === taskName.toLowerCase() && 
+			`${t.version.major}` === version
+		);
+		
+		if (matchedTask) {
+			return convertTaskDefinitionToReference(matchedTask);
+		}
+	} catch (error) {
+		// Ignorujeme chyby API (není nastaveno nebo chyba sítě)
+	}
+	return null;
+}
+
+/**
  * Handler pro get_task_reference tool.
  */
 export async function handleGetTaskReference(taskName: string): Promise<string> {
@@ -296,70 +368,42 @@ export async function handleGetTaskReference(taskName: string): Promise<string> 
 	const [, name, version] = taskMatch;
 	const httpClient = getDefaultHttpClient();
 
-	// Najdeme task v indexu pro documentationPath
-	let taskInfo: PipelineTask | null;
+	// 1. Zkusíme veřejnou dokumentaci
+	let taskInfo: PipelineTask | null = null;
 	try {
 		taskInfo = await findTaskInIndex(taskName);
 	} catch (error) {
-		if (error instanceof NotFoundError) {
-			return JSON.stringify({
-				error: "Task index not found. The documentation source may be unavailable.",
-				url: TASK_INDEX_URL,
-			});
-		}
-		throw error;
+		// Ignorujeme chybu indexu pro teď, zkusíme API fallback
 	}
 
+	if (taskInfo) {
+		// Fetchneme dokumentaci
+		const docUrl = `${TASK_REFERENCE_BASE_URL}${taskInfo.documentationPath}`;
+		try {
+			const markdown = await httpClient.fetch(docUrl, { cacheTtlMs: TASK_REFERENCE_CACHE_TTL_MS });
+			const reference = parseTaskMarkdown(markdown, name, version);
+			return JSON.stringify(reference, null, 2);
+		} catch (error) {
+			// Pokud dokumentace neexistuje, zkusíme API fallback
+		}
+	}
+
+	// 2. Fallback: Azure DevOps API
+	const apiReference = await findTaskInOrganization(name, version);
+	if (apiReference) {
+		return JSON.stringify(apiReference, null, 2);
+	}
+
+	// 3. Nic se nenašlo
 	if (!taskInfo) {
 		return JSON.stringify({
-			error: `Task '${taskName}' not found. Use search_pipeline_tasks to find available tasks.`,
+			error: `Task '${taskName}' not found in public index or organization.`,
+		});
+	} else {
+		return JSON.stringify({
+			error: `Documentation for task '${taskName}' not found in public docs or organization.`,
+			url: `${TASK_REFERENCE_BASE_URL}${taskInfo.documentationPath}`,
 		});
 	}
-
-	// Fetchneme dokumentaci
-	const docUrl = `${TASK_REFERENCE_BASE_URL}${taskInfo.documentationPath}`;
-	try {
-		const markdown = await httpClient.fetch(docUrl, { cacheTtlMs: TASK_REFERENCE_CACHE_TTL_MS });
-		const reference = parseTaskMarkdown(markdown, name, version);
-		return JSON.stringify(reference, null, 2);
-	} catch (error) {
-		if (error instanceof NotFoundError) {
-			return JSON.stringify({
-				error: `Documentation for task '${taskName}' not found.`,
-				url: docUrl,
-			});
-		}
-		throw error;
-	}
 }
 
-/**
- * Registruje get_task_reference tool na MCP server.
- */
-export function registerTaskReferenceTools(server: McpServer): void {
-	server.registerTool(
-		"get_task_reference",
-		{
-			title: "Get Task Reference",
-			description:
-				"Get detailed reference documentation for a specific Azure Pipelines task — inputs, syntax, output variables, and examples. Use search_pipeline_tasks first to find the correct task name.",
-			inputSchema: {
-				taskName: z
-					.string()
-					.describe(
-						"Task name with version in format TaskName@Version (e.g., DotNetCoreCLI@2, Docker@2)."
-					),
-			},
-		},
-		async ({ taskName }) => {
-			return {
-				content: [
-					{
-						type: "text" as const,
-						text: await handleGetTaskReference(taskName),
-					},
-				],
-			};
-		}
-	);
-}

--- a/src/tools/task-reference.ts
+++ b/src/tools/task-reference.ts
@@ -407,3 +407,34 @@ export async function handleGetTaskReference(taskName: string): Promise<string> 
 	}
 }
 
+/**
+ * Registruje get_task_reference tool na MCP server.
+ */
+export function registerTaskReferenceTools(server: McpServer): void {
+	server.registerTool(
+		"get_task_reference",
+		{
+			title: "Get Task Reference",
+			description:
+				"Get detailed reference documentation for a specific Azure Pipelines task — inputs, syntax, output variables, and examples. Use search_pipeline_tasks first to find the correct task name.",
+			inputSchema: {
+				taskName: z
+					.string()
+					.describe(
+						"Task name with version in format TaskName@Version (e.g., DotNetCoreCLI@2, Docker@2)."
+					),
+			},
+		},
+		async ({ taskName }) => {
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: await handleGetTaskReference(taskName),
+					},
+				],
+			};
+		}
+	);
+}
+

--- a/src/tools/variables.ts
+++ b/src/tools/variables.ts
@@ -15,7 +15,7 @@ export function getVariablesReference(category?: string): string {
       availableCategories: CATEGORIES.map((key) => ({
         id: key,
         title: variablesData.categories[key].title,
-        description: variablesData.categories[key].description,
+        description: "description" in variablesData.categories[key] ? variablesData.categories[key].description : undefined,
         count: variablesData.categories[key].variables.length,
       })),
     };

--- a/tests/tools/task-reference.test.ts
+++ b/tests/tools/task-reference.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
 	parseDescription,
 	parseSyntax,
@@ -10,8 +10,13 @@ import {
 	parseTaskMarkdown,
 	handleGetTaskReference,
 } from "../../src/tools/task-reference.js";
+import { resetDefaultHttpClient } from "../../src/services/http-client.js";
+import { resetDefaultCache } from "../../src/services/cache.js";
 
-// Sample markdown simulující strukturu reálné task dokumentace
+// Mock environment variables
+const originalEnv = process.env;
+
+// Sample markdown pro testování
 const SAMPLE_TASK_MARKDOWN = `---
 title: DotNetCoreCLI@2 - .NET Core v2 task
 description: Build, test, package, or publish a .NET application.


### PR DESCRIPTION
## Description
This PR adds support for searching organization-specific tasks in the `search_pipeline_tasks` tool.

### Changes
- **AzureDevOpsClient**: Added `getTaskDefinitions` method to fetch task definitions directly from the Azure DevOps organization API (`_apis/distributedtask/tasks`).
- **search-tasks tool**: Updated `handleSearchPipelineTasks` to:
    1. Attempt to fetch tasks from the configured Azure DevOps organization first.
    2. Map API task definitions to the `PipelineTask` format.
    3. Fall back to scraping public GitHub documentation if organization credentials are not provided or if the API call fails.
- **Tests**: 
    - Added unit tests for `AzureDevOpsClient.getTaskDefinitions`.
    - Added comprehensive tests for `handleSearchPipelineTasks` covering API search, missing credential fallback, and API failure fallback.
    - Added cache reset in tests to ensure isolation.

### How to test
1. Configure `AZURE_DEVOPS_ORG` and `AZURE_DEVOPS_PAT`.
2. Run `search_pipeline_tasks` with a query. It should return tasks from your organization (source: `azure-devops-api`).
3. Unset environment variables and run the same tool. It should return tasks from public docs (source: `public-docs`).